### PR TITLE
imp: facts-Darwin.fact tweaks

### DIFF
--- a/share/sofin/facts/facts-Darwin.fact
+++ b/share/sofin/facts/facts-Darwin.fact
@@ -18,6 +18,7 @@ CHFLAGS_BIN="/usr/bin/chflags"
 
 # set core parameters:
 ALL_CPUS="$(${SYSCTL_BIN} -e machdep.cpu.thread_count 2>/dev/null | ${CUT_BIN} -d'=' -f2 2>/dev/null)"
-CPUS="$(printf "%s\n" "${ALL_CPUS:-${DEFAULT_CPUS}} - 3" | ${BC_BIN} 2>/dev/null)" # decrease threads by 3 on workstation OS
+CPUS="$(printf "%s\n" "${ALL_CPUS:-${DEFAULT_CPUS}} * 0.75 / 1" | ${BC_BIN} 2>/dev/null)" # use only 3/4 of CPU threads on workstation OS
 MAKE_OPTS="-s -j${CPUS:-${DEFAULT_CPUS}}"
-MINIMAL_MAJOR_OS_VERSION="10.11"
+CURRENT_MINIMAL_MAJOR_OS_VERSION="$(${SOFIN_OS_VER_BIN} 2>/dev/null)"
+MINIMAL_MAJOR_OS_VERSION="${CURRENT_MINIMAL_MAJOR_OS_VERSION:-10.11}"


### PR DESCRIPTION
 - use only 3/4 of CPU threads on workstation OS
 - use current macOS version as MINIMAL_MAJOR_OS_VERSION